### PR TITLE
Add server logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "express": "^4.14.0",
     "express-session": "^1.14.0",
     "mariasql": "^0.2.6",
+    "morgan": "^1.7.0",
     "mysql": "^2.11.1",
     "passport": "^0.3.2",
     "passport-github2": "^0.1.10",

--- a/server/server-config.js
+++ b/server/server-config.js
@@ -1,6 +1,7 @@
 // MODULES =================================================
 var express = require('express');
 var bodyParser = require('body-parser');
+var morgan = require('morgan');
 var Sequelize = require('sequelize');
 var session = require('express-session');
 var passport = require('passport');
@@ -25,6 +26,7 @@ var app = express();
 var db = require('./db');
 var utils = require('./db/dbControllers');
 
+app.use(morgan('dev')); // TODO: only run in development environment
 app.use(bodyParser.json());
 // parse application/x-www-form-urlencoded
 app.use(bodyParser.urlencoded({ extended: true }));


### PR DESCRIPTION
We need some simple logging on server side in order to see incoming requests. This helps with QAing the API.

However, not sure we need this in production or not.
The output is one line per incoming request in this format:

```
POST /api/messages/ 200 35.332 ms - 134
```
